### PR TITLE
Błąd działania przy długich nazwach elementów

### DIFF
--- a/smkroz06.py
+++ b/smkroz06.py
@@ -23,11 +23,11 @@ import tkinter
 
 
 def arkusz(): 
-    lista = os.listdir('./arkusz')
+    lista = os.listdir('arkusz')
     duzaDf = pd.DataFrame()
     for l in range(len(lista)):
         try:
-            xls_file = pd.ExcelFile(os.path.join('./arkusz', lista[l]))
+            xls_file = pd.ExcelFile(os.path.join('arkusz', lista[l]))
         except ValueError:
             print("Cannot read file "+lista[l], file=sys.stderr)
             continue


### PR DESCRIPTION
Pull request dotyczy jedynie części związanej z procedurami (smkroz06).

Program nie działa, gdy elementy rozwijanej listy (np. nazwy szpitali) są bardzo długie. Zamiast `select_by_index` trzeba użyć `send_keys`. 

Ten pull request implementuje powyższę zmianę. Nawet jeśli Autor pierwotnej wersji już tu nie zagląda i nie będzie chciał go włączyć do swojego kodu, to może ktoś z użytkowników znajdzie tę informację i skorzysta ze zmienionego repozytorium. 